### PR TITLE
Add support for Hostinterface call

### DIFF
--- a/lib/zabby/zclass.rb
+++ b/lib/zabby/zclass.rb
@@ -139,6 +139,12 @@ module Zabby
     add_zmethods :create, :delete, :exists, :get, :massAdd, :massRemove, :massUpdate, :update
   end
 
+  class Hostinterface
+    include ZClass
+    primary_key :interfaceid
+    add_zmethods :create, :delete, :exists, :get, :update
+  end
+
   class Image
     include ZClass
     primary_key :imageid


### PR DESCRIPTION
Zabbix API allows to get the information about host interfaces using a [Hostinterface call](https://www.zabbix.com/documentation/2.0/manual/appendix/api/hostinterface).

This patch adds the support for the call.
