### PR TITLE
Add a zclass for the 'IT Services'

### DIFF
--- a/lib/zabby/zclass.rb
+++ b/lib/zabby/zclass.rb
@@ -175,6 +175,12 @@ module Zabby
     add_zmethods :get
   end
 
+  class Service
+    include ZClass
+    primary_key :serviceid
+    add_zmethods :addDependencies, :addTimes, :create, :delete, :deleteDependencies, :deleteTimes, :get,  :getSla, :update
+  end
+
   class Screen
     include ZClass
     primary_key :screenid


### PR DESCRIPTION
The IT services API is currently not integrated with Zabby - this patch adds a zclass with the relevant methods. Official docs: https://www.zabbix.com/documentation/2.4/manual/api/reference/service
